### PR TITLE
Fix sample column ordering

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -124,8 +124,12 @@ get.vcfdata.func = function(params) {
     }
     options(scipen=0)
     # This is where we make our matrix of genotypes from the vcf.
-    mygt <- extract.gt(vcf.data)
-    
+    mygt <- extract.gt(vcf.sample)
+    mygt <- mygt[,match(sample.fields,colnames(mygt))]
+
+    if ( any(colnames(mygt) != sample.fields)){
+      stop("Sample fields don't match genotype matrix")
+    }
     
     genotype.matrix   = matrix(nrow=(ncol(mygt))*2,ncol=nrow(mygt))
     odds              = seq(1,nrow(genotype.matrix),2)

--- a/R/functions.R
+++ b/R/functions.R
@@ -124,7 +124,9 @@ get.vcfdata.func = function(params) {
     }
     options(scipen=0)
     # This is where we make our matrix of genotypes from the vcf.
-    mygt <- extract.gt(vcf.sample)
+    mygt <- extract.gt(vcf.data)
+    
+    
     genotype.matrix   = matrix(nrow=(ncol(mygt))*2,ncol=nrow(mygt))
     odds              = seq(1,nrow(genotype.matrix),2)
     pb                = txtProgressBar(1,length(odds),1,style=3)


### PR DESCRIPTION
Hi @jhavsmith 

I noticed an issue where my results were not making sense and tracked it back to the issue in this pull request.  I think this is caused by vcfR which scrambles the columns if the format field is removed (as is done in startmrca). 

I added a line of code to fix the columns and another to check to make sure they are correct.  